### PR TITLE
CPF and CNPJ digit verifying check format before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- CPFGenerator.valid_verification_digit? returning false if document does not have CPF format;
+- CNPJGenerator.valid_verification_digit? returning false if document does not have CNPJ format;
+
 ## [1.0.1] - 2020-22-10
 
 ### Added

--- a/lib/bra_documents/cnpj_generator.rb
+++ b/lib/bra_documents/cnpj_generator.rb
@@ -55,7 +55,7 @@ module BraDocuments
       #   # => true
       def valid_verification_digit?(document:)
         raw_document = Formatter.raw(document)
-        return false if raw_document.chars.uniq.size == 1
+        return false if black_listed?(raw_document) || !Matcher.match?(raw_document, kind: :cnpj, mode: :raw)
 
         company_number = raw_document.slice(0..(COMPANY_NUMBER_SIZE - 1))
         matrix_subsidiary_number = raw_document

--- a/lib/bra_documents/cpf_generator.rb
+++ b/lib/bra_documents/cpf_generator.rb
@@ -41,7 +41,7 @@ module BraDocuments
       #   # => true
       def valid_verification_digit?(document:)
         raw_document = Formatter.raw(document)
-        return false if raw_document.chars.uniq.size == 1
+        return false if black_listed?(raw_document) || !Matcher.match?(raw_document, kind: :cpf, mode: :raw)
 
         person_number = raw_document.slice(0..(PERSON_NUMBER_SIZE - 1))
         verified_digit = raw_document.slice(PERSON_NUMBER_SIZE..(raw_document.size - 1))

--- a/lib/bra_documents/national_register_base.rb
+++ b/lib/bra_documents/national_register_base.rb
@@ -46,6 +46,10 @@ module BraDocuments
           .with_index { |multiplicator, position| numbers[position] * multiplicator }
           .sum
       end
+
+      def black_listed?(numbers)
+        numbers.chars.uniq.size == 1
+      end
     end
   end
 end

--- a/spec/bra_documents/cnpj_generator_spec.rb
+++ b/spec/bra_documents/cnpj_generator_spec.rb
@@ -157,7 +157,13 @@ RSpec.describe BraDocuments::CNPJGenerator do
 
   describe '#valid_verification_digit?' do
     context 'when cnpj is raw' do
-      context 'and all numbers are equal' do
+      context 'but cnpj does not have a valid format' do
+        it 'is invalid verification digit' do
+          expect(described_class).not_to be_valid_verification_digit(document: '')
+        end
+      end
+
+      context 'but all numbers are equal' do
         it 'is invalid verification digit' do
           expect(described_class).not_to be_valid_verification_digit(document: '11111111111111')
         end
@@ -179,7 +185,13 @@ RSpec.describe BraDocuments::CNPJGenerator do
     end
 
     context 'when cnpj is formatted' do
-      context 'and all numbers are equal' do
+      context 'but cnpj does not have a valid format' do
+        it 'is invalid verification digit' do
+          expect(described_class).not_to be_valid_verification_digit(document: '57.153.713/00001-02')
+        end
+      end
+
+      context 'but all numbers are equal' do
         it 'is invalid verification digit' do
           expect(described_class).not_to be_valid_verification_digit(document: '11.111.111/1111-11')
         end

--- a/spec/bra_documents/cpf_generator_spec.rb
+++ b/spec/bra_documents/cpf_generator_spec.rb
@@ -64,7 +64,13 @@ RSpec.describe BraDocuments::CPFGenerator do
 
   describe '#valid_verification_digit?' do
     context 'when cpf is raw' do
-      context 'and all numbers are equal' do
+      context 'but document does not have a cpf format' do
+        it 'is invalid verification digit' do
+          expect(described_class).not_to be_valid_verification_digit(document: '')
+        end
+      end
+
+      context 'but all numbers are equal' do
         it 'is invalid verification digit' do
           expect(described_class).not_to be_valid_verification_digit(document: '11111111111')
         end
@@ -86,7 +92,13 @@ RSpec.describe BraDocuments::CPFGenerator do
     end
 
     context 'when cpf is formatted' do
-      context 'and all numbers are equal' do
+      context 'but document does not have a cpf format' do
+        it 'is invalid verification digit' do
+          expect(described_class).not_to be_valid_verification_digit(document: '123.456.700-980')
+        end
+      end
+
+      context 'but all numbers are equal' do
         it 'is invalid verification digit' do
           expect(described_class).not_to be_valid_verification_digit(document: '111.111.111-11')
         end


### PR DESCRIPTION
It´s breaking when the document does not have a valid format because it can not get the verification digit.